### PR TITLE
Ensure consistent Moscow timezone handling

### DIFF
--- a/backend/src/Controllers/ReservationsController.php
+++ b/backend/src/Controllers/ReservationsController.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace App\Controllers;
 use App\DB;
+use App\Time;
 use function App\json;
 
 class ReservationsController {
@@ -9,22 +10,34 @@ class ReservationsController {
     $from=$_GET['from']??null; $to=$_GET['to']??null;
     if($from&&$to){
       $st=DB::pdo()->prepare("SELECT * FROM reservation WHERE startAt>=? AND endAt<=? ORDER BY startAt DESC");
-      $st->execute([$from,$to]); return json($res,$st->fetchAll());
+      $st->execute([Time::fromClient($from),Time::fromClient($to)]);
+      $rows=$st->fetchAll();
+    } else {
+      $st=DB::pdo()->query("SELECT * FROM reservation ORDER BY startAt DESC LIMIT 200");
+      $rows=$st->fetchAll();
     }
-    $st=DB::pdo()->query("SELECT * FROM reservation ORDER BY startAt DESC LIMIT 200");
-    return json($res,$st->fetchAll());
+    foreach($rows as &$r){$r['startAt']=Time::toClient($r['startAt']);$r['endAt']=Time::toClient($r['endAt']);}
+    return json($res,$rows);
   }
   public function create($req,$res){
     $d=(array) json_decode((string)$req->getBody(), true);
     $id='r_'.bin2hex(random_bytes(9));
+    try{$start=Time::fromClient($d['startAt']);$end=Time::fromClient($d['endAt']);}catch(\Exception $e){return json($res,['error'=>'Invalid datetime'],400);}
     DB::pdo()->prepare("INSERT INTO reservation (id,resourceId,customerId,status,startAt,endAt,prepayAmount,notes) VALUES (?,?,?,?,?,?,?,?)")
-      ->execute([$id,$d['resourceId'],$d['customerId'],$d['status']??'HELD',$d['startAt'],$d['endAt'],$d['prepayAmount']??null,$d['notes']??null]);
+      ->execute([$id,$d['resourceId'],$d['customerId'],$d['status']??'HELD',$start,$end,$d['prepayAmount']??null,$d['notes']??null]);
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
     $id=$args['id']; $d=(array) json_decode((string)$req->getBody(), true);
     $fields=[];$vals=[];
-    foreach(['status','startAt','endAt','prepayAmount','notes'] as $f) if(array_key_exists($f,$d)){ $fields[]="$f=?"; $vals[]=$d[$f]; }
+    foreach(['status','startAt','endAt','prepayAmount','notes'] as $f){
+      if(array_key_exists($f,$d)){
+        $fields[]="$f=?";
+        if(in_array($f,['startAt','endAt'])){
+          try{$vals[]=Time::fromClient($d[$f]);}catch(\Exception $e){return json($res,['error'=>'Invalid datetime'],400);} 
+        } else $vals[]=$d[$f];
+      }
+    }
     if($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE reservation SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }
     return json($res,['ok'=>true]);
   }

--- a/backend/src/Time.php
+++ b/backend/src/Time.php
@@ -1,0 +1,14 @@
+<?php
+namespace App;
+class Time {
+    const TZ = 'Europe/Moscow';
+    public static function fromClient(string $iso): string {
+        $dt = new \DateTime($iso);
+        $dt->setTimezone(new \DateTimeZone(self::TZ));
+        return $dt->format('Y-m-d H:i:s');
+    }
+    public static function toClient(string $db): string {
+        $dt = new \DateTime($db, new \DateTimeZone(self::TZ));
+        return $dt->format(DATE_ATOM);
+    }
+}

--- a/backend/tests/TimeTest.php
+++ b/backend/tests/TimeTest.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../src/Time.php';
+use App\Time;
+assert(Time::fromClient('2024-05-01T09:00:00Z')==='2024-05-01 12:00:00');
+assert(Time::toClient('2024-05-01 12:00:00')==='2024-05-01T12:00:00+03:00');
+echo "Time tests passed\n";

--- a/main-dir/app/page.tsx
+++ b/main-dir/app/page.tsx
@@ -13,6 +13,7 @@ import { Switch } from "@/components/ui/switch";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ShoppingCart, Scale, Calendar as CalendarIcon, Users, BarChart2, Settings, Trash2, Plus, Minus, CreditCard, Wallet } from "lucide-react";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend, BarChart, Bar } from "recharts";
+import { todayMoscowISO, toMoscowSlotISO } from "@/lib/time";
 
 // ---------- Helpers / constants ----------
 const NONE = "__NONE__"; // sentinel for empty Select choice (valid non-empty string)
@@ -20,7 +21,6 @@ const NONE = "__NONE__"; // sentinel for empty Select choice (valid non-empty st
 const currency = (n:number) => new Intl.NumberFormat("ru-RU", { style: "currency", currency: "RUB", maximumFractionDigits: 2 }).format(n || 0);
 const kg = (n:number) => `${(n ?? 0).toFixed(2)} кг`;
 const rand = (min:number, max:number) => Math.random() * (max - min) + min;
-const todayISO = () => new Date().toISOString().slice(0, 10);
 
 const LS = {
   products: "fishing_products",
@@ -425,7 +425,7 @@ function PayDialog({ amount, onCancel, onConfirm, customerId, customers, setCust
 function Reservations({ gazebos, customers, reservations, setReservations }:{
   gazebos:any[], customers:any[], reservations:any[], setReservations:any
 }){
-  const [date, setDate] = useState(todayISO());
+  const [date, setDate] = useState(todayMoscowISO());
   const [selGazebo, setSelGazebo] = useState<string>(gazebos[0]?.id ?? NONE);
   const hours = Array.from({length: 15}, (_,i)=> i+8); // 08..22
 
@@ -436,8 +436,8 @@ function Reservations({ gazebos, customers, reservations, setReservations }:{
 
   function toggleSlot(hour:number){
     if (selGazebo === NONE) return;
-    const startAt = new Date(`${date}T${String(hour).padStart(2,'0')}:00:00`).toISOString();
-    const endAt = new Date(`${date}T${String(hour+1).padStart(2,'0')}:00:00`).toISOString();
+    const startAt = toMoscowSlotISO(date,hour);
+    const endAt = toMoscowSlotISO(date,hour+1);
     const existing = (dayRes as any[]).find(r => r.startAt===startAt);
     if (existing){
       setReservations(reservations.filter(r => r.id !== existing.id));

--- a/main-dir/lib/time.d.ts
+++ b/main-dir/lib/time.d.ts
@@ -1,0 +1,2 @@
+export function todayMoscowISO(): string;
+export function toMoscowSlotISO(date: string, hour: number): string;

--- a/main-dir/lib/time.js
+++ b/main-dir/lib/time.js
@@ -1,0 +1,8 @@
+export function todayMoscowISO(){
+  const now = new Date();
+  const moscowNow = new Date(now.toLocaleString('en-US',{timeZone:'Europe/Moscow'}));
+  return moscowNow.toISOString().slice(0,10);
+}
+export function toMoscowSlotISO(date,hour){
+  return `${date}T${String(hour).padStart(2,'0')}:00:00+03:00`;
+}

--- a/main-dir/test/time.test.mjs
+++ b/main-dir/test/time.test.mjs
@@ -1,0 +1,5 @@
+import assert from 'assert';
+import { todayMoscowISO, toMoscowSlotISO } from '../lib/time.js';
+assert.strictEqual(toMoscowSlotISO('2024-05-01',12),'2024-05-01T12:00:00+03:00');
+assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(todayMoscowISO()));
+console.log('Frontend time tests passed');


### PR DESCRIPTION
## Summary
- normalize reservation timestamps to Moscow time on server
- add reusable frontend helpers for Moscow time slots
- validate conversion logic with simple PHP and Node tests

## Testing
- `php -d assert.exception=1 backend/tests/TimeTest.php`
- `node main-dir/test/time.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b741194634832eac2b411131362f8e