### PR TITLE
Add phone mask and validation for customers

### DIFF
--- a/backend/src/Controllers/CustomersController.php
+++ b/backend/src/Controllers/CustomersController.php
@@ -17,9 +17,13 @@ class CustomersController {
   }
   public function create($req,$res){
     $d=(array) json_decode((string)$req->getBody(), true);
+    $phone=$d['phone']??'';
+    if(!preg_match('/^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/',$phone)){
+      return json($res,['error'=>'Invalid phone'],400);
+    }
     $id='c_'.bin2hex(random_bytes(9));
     DB::pdo()->prepare("INSERT INTO customer (id,fullName,phone,email,birthday,notes,createdAt) VALUES (?,?,?,?,?,?,NOW())")
-      ->execute([$id,$d['fullName'],$d['phone'],$d['email']??null,$d['birthday']??null,$d['notes']??null]);
+      ->execute([$id,$d['fullName'],$phone,$d['email']??null,$d['birthday']??null,$d['notes']??null]);
     return json($res,['id'=>$id],201);
   }
 }

--- a/main-dir/components/customers/CustomerForm.tsx
+++ b/main-dir/components/customers/CustomerForm.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import InputMask from "react-input-mask";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+export interface CustomerFormProps {
+  initial?: { fullName?: string; phone?: string };
+  onSubmit: (payload: { fullName: string; phone: string }) => void;
+}
+
+export function CustomerForm({ initial, onSubmit }: CustomerFormProps) {
+  const [fullName, setFullName] = useState(initial?.fullName ?? "");
+  const [phone, setPhone] = useState(initial?.phone ?? "");
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    onSubmit({ fullName, phone });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div>
+        <Label htmlFor="fullName">ФИО</Label>
+        <Input
+          id="fullName"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label htmlFor="phone">Телефон</Label>
+        <InputMask
+          mask="+7 (999) 999-99-99"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        >
+          {(inputProps: any) => <Input id="phone" {...inputProps} />}
+        </InputMask>
+      </div>
+      <Button type="submit">Сохранить</Button>
+    </form>
+  );
+}
+
+export default CustomerForm;
+

--- a/main-dir/package-lock.json
+++ b/main-dir/package-lock.json
@@ -19,6 +19,7 @@
         "next": "14.2.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-input-mask": "^2.0.4",
         "recharts": "^2.12.7",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7"
@@ -2112,6 +2113,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2703,6 +2713,20 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
       }
     },
     "node_modules/react-is": {
@@ -3392,6 +3416,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/main-dir/package.json
+++ b/main-dir/package.json
@@ -23,7 +23,8 @@
     "react-dom": "18.2.0",
     "recharts": "^2.12.7",
     "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "react-input-mask": "^2.0.4"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",


### PR DESCRIPTION
## Summary
- add `react-input-mask` and apply Russian phone mask in customer form
- validate phone number format on customer creation API

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74795d56c832eb7e0fcc087872d49