### PR TITLE
Add weight field for products and compute order totals by weight

### DIFF
--- a/main-dir/components/pos/WeightProduct.tsx
+++ b/main-dir/components/pos/WeightProduct.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, FormEvent, ChangeEvent } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+export interface WeightProductProps {
+  onSubmit: (payload: { weightKg: number }) => void;
+}
+
+export default function WeightProduct({ onSubmit }: WeightProductProps) {
+  const [weight, setWeight] = useState("");
+
+  function handleWeightChange(e: ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    if (value === "" || /^\d+(\.\d{0,2})?$/.test(value)) {
+      setWeight(value);
+    }
+  }
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const w = parseFloat(weight);
+    if (!isNaN(w)) {
+      onSubmit({ weightKg: w });
+      setWeight("");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div>
+        <Label htmlFor="weight">Вес (кг)</Label>
+        <Input
+          id="weight"
+          type="number"
+          min="0"
+          step={0.01}
+          value={weight}
+          onChange={handleWeightChange}
+        />
+      </div>
+      <Button type="submit">Добавить</Button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add weight (kg) field with 10g precision in WeightProduct form
- compute order totals using provided weight on backend

## Testing
- `npm test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b74a969d28832ea98192c84222a5c7