### PR TITLE
feat: add admin products section and product API

### DIFF
--- a/backend/src/Controllers/ProductsController.php
+++ b/backend/src/Controllers/ProductsController.php
@@ -35,5 +35,10 @@ class ProductsController {
     }
     return json($res,['ok'=>true]);
   }
+  public function delete($req,$res,$args){
+    $id=$args['id'];
+    DB::pdo()->prepare("DELETE FROM product WHERE id=?")->execute([$id]);
+    return json($res,['ok'=>true]);
+  }
   private static function cuid($p){ return $p.'_'.bin2hex(random_bytes(9)); }
 }

--- a/main-dir/app/admin/products/ProductForm.tsx
+++ b/main-dir/app/admin/products/ProductForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+export interface Product {
+  id?: string;
+  name: string;
+  sku?: string;
+  type: "GOOD" | "SERVICE";
+  unit: "KG" | "HOUR" | "PIECE";
+  price?: number;
+  currentPrice?: number;
+}
+
+export interface ProductFormProps {
+  initial?: Product | null;
+  onSaved: () => void;
+}
+
+export default function ProductForm({ initial, onSaved }: ProductFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [sku, setSku] = useState(initial?.sku ?? "");
+  const [type, setType] = useState<Product["type"]>(initial?.type ?? "GOOD");
+  const [unit, setUnit] = useState<Product["unit"]>(initial?.unit ?? "PIECE");
+  const [price, setPrice] = useState<string>(
+    initial?.currentPrice?.toString() ?? initial?.price?.toString() ?? ""
+  );
+
+  useEffect(() => {
+    setName(initial?.name ?? "");
+    setSku(initial?.sku ?? "");
+    setType(initial?.type ?? "GOOD");
+    setUnit(initial?.unit ?? "PIECE");
+    setPrice(initial?.currentPrice?.toString() ?? initial?.price?.toString() ?? "");
+  }, [initial]);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const payload: any = { name, sku, type, unit };
+    if (price !== "") payload.price = Number(price);
+    const url = initial?.id ? `/api/products/${initial.id}` : "/api/products";
+    await fetch(url, {
+      method: initial?.id ? "PUT" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    onSaved();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div>
+        <Label htmlFor="name">Название</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <Label htmlFor="sku">SKU</Label>
+        <Input id="sku" value={sku} onChange={(e) => setSku(e.target.value)} />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Тип</Label>
+          <Select value={type} onValueChange={(v) => setType(v as any)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="GOOD">GOOD</SelectItem>
+              <SelectItem value="SERVICE">SERVICE</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label>Ед.</Label>
+          <Select value={unit} onValueChange={(v) => setUnit(v as any)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="KG">KG</SelectItem>
+              <SelectItem value="HOUR">HOUR</SelectItem>
+              <SelectItem value="PIECE">PIECE</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div>
+        <Label htmlFor="price">Цена</Label>
+        <Input
+          id="price"
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+      </div>
+      <Button type="submit">Сохранить</Button>
+    </form>
+  );
+}
+

--- a/main-dir/app/admin/products/ProductList.tsx
+++ b/main-dir/app/admin/products/ProductList.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export interface Product {
+  id: string;
+  name: string;
+  currentPrice?: number;
+}
+
+export interface ProductListProps {
+  products: Product[];
+  onEdit: (p: Product) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function ProductList({ products, onEdit, onDelete }: ProductListProps) {
+  if (products.length === 0) {
+    return <p>Нет товаров</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {products.map((p) => (
+        <div
+          key={p.id}
+          className="flex items-center justify-between border rounded p-2"
+        >
+          <div>
+            <div className="font-medium">{p.name}</div>
+            {p.currentPrice !== undefined && (
+              <div className="text-sm text-muted-foreground">
+                {p.currentPrice}
+              </div>
+            )}
+          </div>
+          <div className="space-x-2">
+            <Button size="sm" onClick={() => onEdit(p)}>
+              Редактировать
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => onDelete(p.id)}
+            >
+              Удалить
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/main-dir/app/admin/products/page.tsx
+++ b/main-dir/app/admin/products/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ProductForm from "./ProductForm";
+import ProductList from "./ProductList";
+import type { Product } from "./ProductForm";
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [editing, setEditing] = useState<Product | null>(null);
+
+  async function load() {
+    const res = await fetch("/api/products");
+    const data = await res.json();
+    setProducts(data);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleDelete(id: string) {
+    await fetch(`/api/products/${id}`, { method: "DELETE" });
+    load();
+  }
+
+  function handleSaved() {
+    setEditing(null);
+    load();
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Products</h1>
+      <ProductForm initial={editing} onSaved={handleSaved} />
+      <ProductList
+        products={products}
+        onEdit={(p) => setEditing(p)}
+        onDelete={handleDelete}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin products list and editor form
- enable product create, update and delete API methods

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b74ca93250832ebdcede10dd04b8b3