### PR TITLE
Enforce customer selection for reservations

### DIFF
--- a/backend/src/Controllers/ReservationsController.php
+++ b/backend/src/Controllers/ReservationsController.php
@@ -28,10 +28,10 @@ class ReservationsController {
     }catch(\Exception $e){
       return json($res,['error'=>'Invalid datetime'],400);
     }
-    $customerId=$d['customer_id']??null;
-    if(!$customerId){
+    if(empty($d['customer_id'])){
       return json($res,['error'=>'customer_id required'],400);
     }
+    $customerId=$d['customer_id'];
     DB::pdo()->prepare("INSERT INTO reservation (id,resourceId,customerId,status,startAt,endAt,prepayAmount,notes) VALUES (?,?,?,?,?,?,?,?)")
       ->execute([$id,$d['resourceId'],$customerId,$d['status']??'HELD',$start,$end,$d['prepayAmount']??null,$d['notes']??null]);
     return json($res,['id'=>$id],201);

--- a/main-dir/components/reservations/ReservationForm.tsx
+++ b/main-dir/components/reservations/ReservationForm.tsx
@@ -40,6 +40,10 @@ export function ReservationForm({ customers, onSubmit }: ReservationFormProps) {
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (!customerId) {
+      alert("Customer is required");
+      return;
+    }
     let id = customerId;
     if (id === "new") {
       id = await createCustomer();
@@ -57,7 +61,7 @@ export function ReservationForm({ customers, onSubmit }: ReservationFormProps) {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="customer">Customer</Label>
-        <Select value={customerId} onValueChange={setCustomerId}>
+        <Select value={customerId} onValueChange={setCustomerId} aria-required="true">
           <SelectTrigger id="customer">
             <SelectValue placeholder="Select customer" />
           </SelectTrigger>
@@ -99,7 +103,7 @@ export function ReservationForm({ customers, onSubmit }: ReservationFormProps) {
         <Label htmlFor="notes">Notes</Label>
         <Input id="notes" name="notes" />
       </div>
-      <Button type="submit">Save</Button>
+      <Button type="submit" disabled={!customerId}>Save</Button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- validate `customer_id` is provided when creating reservations
- require customer selection in reservation form and disable save button until chosen

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74ef537d4832e8223d43df21fd466