### PR TITLE
feat: add login page and auth middleware

### DIFF
--- a/main-dir/app/admin/products/ProductForm.tsx
+++ b/main-dir/app/admin/products/ProductForm.tsx
@@ -11,16 +11,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-
-export interface Product {
-  id?: string;
-  name: string;
-  sku?: string;
-  type: "GOOD" | "SERVICE";
-  unit: "KG" | "HOUR" | "PIECE";
-  price?: number;
-  currentPrice?: number;
-}
+import type { Product } from "./types";
 
 export interface ProductFormProps {
   initial?: Product | null;

--- a/main-dir/app/admin/products/ProductList.tsx
+++ b/main-dir/app/admin/products/ProductList.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-
-export interface Product {
-  id: string;
-  name: string;
-  currentPrice?: number;
-}
+import type { Product } from "./types";
 
 export interface ProductListProps {
   products: Product[];

--- a/main-dir/app/admin/products/page.tsx
+++ b/main-dir/app/admin/products/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import ProductForm from "./ProductForm";
 import ProductList from "./ProductList";
-import type { Product } from "./ProductForm";
+import type { Product } from "./types";
 
 export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);

--- a/main-dir/app/admin/products/types.ts
+++ b/main-dir/app/admin/products/types.ts
@@ -1,0 +1,10 @@
+export interface Product {
+  id: string;
+  name: string;
+  sku?: string;
+  type: "GOOD" | "SERVICE";
+  unit: "KG" | "HOUR" | "PIECE";
+  price?: number;
+  currentPrice?: number;
+}
+

--- a/main-dir/app/api/login/route.ts
+++ b/main-dir/app/api/login/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+  if (username === 'admin' && password === 'admin') {
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set('token', 'demo-token', { httpOnly: true, path: '/' });
+    return res;
+  }
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}

--- a/main-dir/app/login/page.tsx
+++ b/main-dir/app/login/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      router.push('/');
+    } else {
+      setError('Неверный логин или пароль');
+    }
+  };
+
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <form onSubmit={onSubmit} className="space-y-4 p-6 border rounded-lg w-full max-w-sm">
+        <div className="text-xl font-bold">Вход</div>
+        <div className="space-y-2">
+          <Label htmlFor="username">Логин</Label>
+          <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Пароль</Label>
+          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        {error && <div className="text-sm text-red-500">{error}</div>}
+        <Button type="submit" className="w-full">Войти</Button>
+      </form>
+    </div>
+  );
+}

--- a/main-dir/middleware.ts
+++ b/main-dir/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token')?.value;
+  const { pathname } = req.nextUrl;
+
+  if (!token && pathname !== '/login' && !pathname.startsWith('/api')) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  if (token && pathname === '/login') {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## Summary
- add login page with username/password form
- implement API route to set demo auth cookie
- add middleware to enforce auth and redirect to login
- centralize Product type to resolve build error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7e08f7b30832ea6b7caf0af6285ff