### PR TITLE
feat: add tooltips to main forms

### DIFF
--- a/main-dir/components/customers/CustomerForm.tsx
+++ b/main-dir/components/customers/CustomerForm.tsx
@@ -5,6 +5,8 @@ import InputMask from "react-input-mask";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
 
 export interface CustomerFormProps {
   initial?: { fullName?: string; phones?: string[] };
@@ -34,6 +36,11 @@ export function CustomerForm({ initial, onSubmit }: CustomerFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
+      <div className="flex justify-end">
+        <Tooltip text="Введите ФИО и телефоны клиента">
+          <Info className="h-4 w-4 text-muted-foreground" />
+        </Tooltip>
+      </div>
       <div>
         <Label htmlFor="fullName">ФИО</Label>
         <Input

--- a/main-dir/components/pos/WeightProduct.tsx
+++ b/main-dir/components/pos/WeightProduct.tsx
@@ -4,6 +4,8 @@ import { useState, FormEvent, ChangeEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
 
 export interface WeightProductProps {
   onSubmit: (payload: { weightKg: number }) => void;
@@ -30,6 +32,11 @@ export default function WeightProduct({ onSubmit }: WeightProductProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
+      <div className="flex justify-end">
+        <Tooltip text="Введите вес товара и нажмите \"Добавить\"">
+          <Info className="h-4 w-4 text-muted-foreground" />
+        </Tooltip>
+      </div>
       <div>
         <Label htmlFor="weight">Вес (кг)</Label>
         <Input

--- a/main-dir/components/reservations/ReservationForm.tsx
+++ b/main-dir/components/reservations/ReservationForm.tsx
@@ -4,6 +4,8 @@ import { useState, FormEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
 import {
   Select,
   SelectTrigger,
@@ -59,6 +61,11 @@ export function ReservationForm({ customers, onSubmit }: ReservationFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex justify-end">
+        <Tooltip text="Выберите клиента и укажите время бронирования">
+          <Info className="h-4 w-4 text-muted-foreground" />
+        </Tooltip>
+      </div>
       <div className="space-y-2">
         <Label htmlFor="customer">Customer</Label>
         <Select value={customerId} onValueChange={setCustomerId} aria-required="true">

--- a/main-dir/components/ui/tooltip.tsx
+++ b/main-dir/components/ui/tooltip.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+export interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+}
+
+export function Tooltip({ text, children }: TooltipProps) {
+  return (
+    <span className="group relative inline-block">
+      {children}
+      <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
+        {text}
+      </span>
+    </span>
+  );
+}
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- add reusable tooltip component
- provide concise guidance for customer, reservation, and weight forms

## Testing
- `cd main-dir && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e8fbb3b8832e8b960b0fd57bb971