### PR TITLE
Add customer search API and selector

### DIFF
--- a/backend/src/Controllers/CustomersController.php
+++ b/backend/src/Controllers/CustomersController.php
@@ -17,6 +17,16 @@ class CustomersController {
     foreach($rows as &$r){ $r['phones']=$r['phones']?explode(',',$r['phones']):[]; }
     return json($res,$rows);
   }
+  public function search($req,$res){
+    $q=$_GET['q']??'';
+    if(!$q){ return json($res,[]); }
+    $st=DB::pdo()->prepare("SELECT c.*,GROUP_CONCAT(cp.phone) phones FROM customer c LEFT JOIN customer_phones cp ON cp.customerId=c.id WHERE c.fullName LIKE ? OR c.phone LIKE ? OR cp.phone LIKE ? GROUP BY c.id ORDER BY c.fullName LIMIT 200");
+    $like="%$q%";
+    $st->execute([$like,$like,$like]);
+    $rows=$st->fetchAll();
+    foreach($rows as &$r){ $r['phones']=$r['phones']?explode(',',$r['phones']):[]; }
+    return json($res,$rows);
+  }
   public function create($req,$res){
     $d=(array) json_decode((string)$req->getBody(), true);
     $phones=$d['phones']??(isset($d['phone'])?[$d['phone']]:[]);

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -1,0 +1,11 @@
+<?php
+use App\Controllers\CustomersController;
+
+$c = new CustomersController();
+
+$app->get('/customers', [$c, 'list']);
+$app->get('/customers/search', [$c, 'search']);
+$app->post('/customers', [$c, 'create']);
+$app->patch('/customers/{id}', [$c, 'update']);
+$app->delete('/customers/{id}', [$c, 'destroy']);
+

--- a/main-dir/components/customers/CustomerSelect.tsx
+++ b/main-dir/components/customers/CustomerSelect.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+export interface CustomerOption {
+  id: string;
+  fullName: string;
+  phones?: string[];
+}
+
+export interface CustomerSelectProps {
+  value: string;
+  onChange: (id: string) => void;
+}
+
+export function CustomerSelect({ value, onChange }: CustomerSelectProps) {
+  const [query, setQuery] = useState("");
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+
+  useEffect(() => {
+    async function fetchCustomers() {
+      const res = await fetch(
+        `/api/customers/search?q=${encodeURIComponent(query)}`
+      );
+      const data = await res.json();
+      setCustomers(data);
+    }
+    fetchCustomers();
+  }, [query]);
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="Поиск по имени или телефону"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <Select value={value} onValueChange={onChange} aria-required="true">
+        <SelectTrigger>
+          <SelectValue placeholder="Выберите клиента" />
+        </SelectTrigger>
+        <SelectContent>
+          {customers.map((c) => (
+            <SelectItem key={c.id} value={c.id}>
+              {c.fullName}
+              {c.phones && c.phones[0] ? ` (${c.phones[0]})` : ""}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export default CustomerSelect;
+


### PR DESCRIPTION
## Summary
- add /customers/search endpoint to filter by name or phone
- add customer select component with search field

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ed883c0c832e8eb3a1cff4334ba2