### PR TITLE
fix: align WeightProduct tooltip props

### DIFF
--- a/main-dir/components/pos/WeightProduct.tsx
+++ b/main-dir/components/pos/WeightProduct.tsx
@@ -33,7 +33,7 @@ export default function WeightProduct({ onSubmit }: WeightProductProps) {
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <div className="flex justify-end">
-        <Tooltip content="Введите вес товара и нажмите «Добавить»">
+        <Tooltip text="Введите вес товара и нажмите «Добавить»">
           <Info className="h-4 w-4 text-muted-foreground cursor-pointer" />
         </Tooltip>
       </div>


### PR DESCRIPTION
## Summary
- fix WeightProduct tooltip usage to pass correct `text` prop

## Testing
- `npm test`
- `npx --yes -p node@20 npm run build` *(fails: Cannot find module '../../server/lib/lru-cache')*

------
https://chatgpt.com/codex/tasks/task_e_68b8041069d0832e87537004ee341348