### PR TITLE
Refactor storage to async Store

### DIFF
--- a/main-dir/lib/store.ts
+++ b/main-dir/lib/store.ts
@@ -6,7 +6,8 @@ const LS_KEYS = {
   products: 'fishing_products',
   customers: 'fishing_customers',
   orders: 'fishing_orders',
-  reservations: 'fishing_reservations'
+  reservations: 'fishing_reservations',
+  settings: 'fishing_settings'
 } as const
 
 function readLS<T>(key: string, fallback: T): T {
@@ -48,6 +49,25 @@ function makeStore(api: any, key: string) {
         return updated
       }
       return null
+    },
+    async delete(id: string | number) {
+      if (USE_API) return api.delete(id)
+      const items = readLS<any[]>(key, [])
+      const filtered = items.filter((it: any) => it.id !== id)
+      writeLS(key, filtered)
+      return id
+    }
+  }
+}
+
+function makeSettingsStore(key: string) {
+  return {
+    async get<T>(fallback: T) {
+      return readLS<T>(key, fallback)
+    },
+    async save<T>(value: T) {
+      writeLS(key, value)
+      return value
     }
   }
 }
@@ -56,7 +76,8 @@ const Store = {
   products: makeStore(new API.Products(), LS_KEYS.products),
   customers: makeStore(new API.Customers(), LS_KEYS.customers),
   orders: makeStore(new API.Orders(), LS_KEYS.orders),
-  reservations: makeStore(new API.Reservations(), LS_KEYS.reservations)
+  reservations: makeStore(new API.Reservations(), LS_KEYS.reservations),
+  settings: makeSettingsStore(LS_KEYS.settings)
 }
 
 export default Store


### PR DESCRIPTION
## Summary
- load and persist app data using asynchronous Store instead of direct localStorage helpers
- extend Store with settings support and deletion API
- await Store responses before updating state across POS, CRM, reservations and admin settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b82b26e300832e80eafeec29aa6f3d