### PR TITLE
Add routes for orders and reservations

### DIFF
--- a/backend/src/Controllers/ReservationsController.php
+++ b/backend/src/Controllers/ReservationsController.php
@@ -50,4 +50,10 @@ class ReservationsController {
     if($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE reservation SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }
     return json($res,['ok'=>true]);
   }
+
+  public function delete($req,$res,$args){
+    $id=$args['id'];
+    DB::pdo()->prepare("DELETE FROM reservation WHERE id=?")->execute([$id]);
+    return json($res,['ok'=>true]);
+  }
 }

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -5,6 +5,8 @@ use App\Controllers\LoyaltyController;
 use App\Controllers\CatalogController;
 use App\Controllers\UsersController;
 use App\Controllers\RolesController;
+use App\Controllers\OrdersController;
+use App\Controllers\ReservationsController;
 
 $c = new CustomersController();
 $app->get('/customers', [$c, 'list']);
@@ -30,6 +32,16 @@ $app->get('/catalog', [$cat, 'list']);
 $app->post('/catalog', [$cat, 'create']);
 $app->put('/catalog/{id}', [$cat, 'update']);
 $app->delete('/catalog/{id}', [$cat, 'delete']);
+
+$o = new OrdersController();
+$app->get('/orders', [$o, 'list']);
+$app->post('/orders', [$o, 'create']);
+
+$res = new ReservationsController();
+$app->get('/reservations', [$res, 'list']);
+$app->post('/reservations', [$res, 'create']);
+$app->patch('/reservations/{id}', [$res, 'update']);
+$app->delete('/reservations/{id}', [$res, 'delete']);
 
 $u = new UsersController();
 $app->get('/users', [$u, 'list']);


### PR DESCRIPTION
## Summary
- Register orders routes and reservations routes in router
- Support deleting reservations

## Testing
- `composer test`
- `php -S 0.0.0.0:8000 -t backend`

------
https://chatgpt.com/codex/tasks/task_e_68b83ab35738832ea0815d06f977b9b7