### PR TITLE
Persist orders via Store after awaiting API save

### DIFF
--- a/main-dir/app/page.tsx
+++ b/main-dir/app/page.tsx
@@ -112,7 +112,10 @@ export default function App() {
           <TabsTrigger value="admin" className="flex items-center gap-2"><Settings className="h-4 w-4"/>Админ</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="pos"><POS products={products} settings={settings} customers={customers} setCustomers={setCustomers} onPaid={async (o:any)=>{ setOrders((os:any[]) => [o, ...os]); }}/></TabsContent>
+        <TabsContent value="pos"><POS products={products} settings={settings} customers={customers} setCustomers={setCustomers} onPaid={async (o:any)=>{
+          const saved = await Store.orders.save(o)
+          setOrders((os:any[]) => [{ ...o, ...saved }, ...os])
+        }}/></TabsContent>
         <TabsContent value="reservations"><Reservations gazebos={DEFAULT_GAZEBOS} customers={customers} reservations={reservations} setReservations={setReservations} /></TabsContent>
         <TabsContent value="crm"><CRM customers={customers} setCustomers={setCustomers} orders={orders}/></TabsContent>
         <TabsContent value="reports"><Reports orders={orders} reservations={reservations} products={products}/></TabsContent>
@@ -214,10 +217,17 @@ function POS({ products, settings, customers, setCustomers, onPaid }:{
       if (updated) setCustomers((cs:any[]) => cs.map(c => c.id===custId ? updated : c))
     }
 
-    const request = { customerId: custId, cashierId: 'u_anon', status, items, payments, totals: totalsFull };
-    const saved = await new API.Orders().create<any>(request);
-    const order = { ...request, ...saved, createdAt: new Date().toISOString(), paidAt: new Date().toISOString() };
-    await onPaid(order);
+    const order = {
+      customerId: custId,
+      cashierId: 'u_anon',
+      status,
+      items,
+      payments,
+      totals: totalsFull,
+      createdAt: new Date().toISOString(),
+      paidAt: new Date().toISOString()
+    }
+    await onPaid(order)
     setCart([]);
     setDiscountPct(0);
     setCustomerId(null);


### PR DESCRIPTION
## Summary
- Save paid orders through the Store so local state updates only after the API confirms persistence
- Delegate order creation to the caller and await Store save before mutating state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b83bb14abc832ebbb6580de622d4b5