### PR TITLE
feat: add typed customer store

### DIFF
--- a/main-dir/app/page.tsx
+++ b/main-dir/app/page.tsx
@@ -67,10 +67,10 @@ export default function App() {
   useEffect(() => {
     (async () => {
       const [p, c, o, r, s] = await Promise.all([
-        Store.products.get<any[]>(),
-        Store.customers.get<any[]>(),
-        Store.orders.get<any[]>(),
-        Store.reservations.get<any[]>(),
+        Store.products.get(),
+        Store.customers.get(),
+        Store.orders.get(),
+        Store.reservations.get(),
         Store.settings.get(DEFAULT_SETTINGS)
       ])
       setProducts((p as any[]).length ? (p as any[]) : DEFAULT_PRODUCTS)
@@ -363,7 +363,7 @@ function LastOrdersMini(){
   const [orders, setOrders] = useState<any[]>([]);
   useEffect(() => {
     (async () => {
-      const o = await Store.orders.get<any[]>();
+      const o = await Store.orders.get();
       setOrders(o)
     })()
   }, [])
@@ -474,7 +474,7 @@ function Reservations({ gazebos, customers, reservations, setReservations }:{
         const r = { resourceId: selGazebo, customerId: customers[0].id, status: "HELD", startAt, endAt, prepayAmount: 0 };
         await reservationsApi.create(r);
       }
-      const updated = await Store.getReservations<any[]>();
+      const updated = await Store.getReservations();
       setReservations(updated);
     } catch (e:any) {
       setError(e.message || 'Не удалось обновить бронирование');

--- a/main-dir/lib/store.ts
+++ b/main-dir/lib/store.ts
@@ -1,4 +1,5 @@
 import API from './api'
+import type { Customer } from './types'
 
 export const USE_API = true
 
@@ -25,25 +26,25 @@ function writeLS<T>(key: string, value: T) {
   localStorage.setItem(key, JSON.stringify(value))
 }
 
-function makeStore(api: any, key: string) {
+function makeStore<T extends { id: string | number } = any>(api: any, key: string) {
   return {
-    async get<T>() {
-      if (USE_API) return api.list<T>()
+    async get() {
+      if (USE_API) return api.list() as Promise<T[]>
       return readLS<T[]>(key, [])
     },
-    async save<T>(item: T) {
-      if (USE_API) return api.create<T>(item)
+    async save(item: T) {
+      if (USE_API) return api.create(item) as Promise<T>
       const items = readLS<T[]>(key, [])
       items.push(item)
       writeLS(key, items)
       return item
     },
-    async saveAll<T>(items: T[]) {
+    async saveAll(items: T[]) {
       if (USE_API) return
       writeLS(key, items)
     },
-    async update<T extends { id: string | number }>(id: string | number, patch: Partial<T>) {
-      if (USE_API) return api.update<T>(id, patch)
+    async update(id: string | number, patch: Partial<T>) {
+      if (USE_API) return api.update(id, patch) as Promise<T>
       const items = readLS<T[]>(key, [])
       const idx = items.findIndex((it: any) => it.id === id)
       if (idx >= 0) {
@@ -65,11 +66,11 @@ function makeStore(api: any, key: string) {
 
 const Store = {
   products: makeStore(new API.Products(), LS_KEYS.products),
-  customers: makeStore(new API.Customers(), LS_KEYS.customers),
+  customers: makeStore<Customer>(new API.Customers(), LS_KEYS.customers),
   orders: makeStore(new API.Orders(), LS_KEYS.orders),
   reservations: makeStore(new API.Reservations(), LS_KEYS.reservations),
-  async getReservations<T>() {
-    return this.reservations.get<T>()
+  async getReservations() {
+    return this.reservations.get()
   },
   settings: {
     async get<T>(fallback: T) {

--- a/main-dir/lib/types.ts
+++ b/main-dir/lib/types.ts
@@ -1,0 +1,5 @@
+export interface Customer {
+  id: string | number;
+  points?: number;
+  // ...other fields...
+}

--- a/main-dir/react-input-mask.d.ts
+++ b/main-dir/react-input-mask.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-input-mask';


### PR DESCRIPTION
## Summary
- add shared `Customer` interface
- make `makeStore` generic and type customers
- align page with typed store usage

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b84e3e8c20832e890159e25e5b5d26