### PR TITLE
feat: allow configurable update method

### DIFF
--- a/main-dir/lib/api.ts
+++ b/main-dir/lib/api.ts
@@ -44,9 +44,9 @@ class Resource {
     })
   }
 
-  update<T>(id: string | number, payload: unknown) {
+  update<T>(id: string | number, payload: unknown, method: string = 'PATCH') {
     return request<T>(`${this.path}/${id}`, {
-      method: 'PUT',
+      method,
       body: JSON.stringify(payload)
     })
   }
@@ -60,11 +60,19 @@ export class Products extends Resource {
   constructor() {
     super('products')
   }
+
+  update<T>(id: string | number, payload: unknown) {
+    return super.update<T>(id, payload, 'PUT')
+  }
 }
 
 export class Customers extends Resource {
   constructor() {
     super('customers')
+  }
+
+  update<T>(id: string | number, payload: unknown) {
+    return super.update<T>(id, payload, 'PATCH')
   }
 }
 
@@ -78,6 +86,20 @@ export class Reservations extends Resource {
   constructor() {
     super('reservations')
   }
+
+  update<T>(id: string | number, payload: unknown) {
+    return super.update<T>(id, payload, 'PATCH')
+  }
 }
 
-export default { Products, Customers, Orders, Reservations }
+export class Users extends Resource {
+  constructor() {
+    super('users')
+  }
+
+  update<T>(id: string | number, payload: unknown) {
+    return super.update<T>(id, payload, 'PATCH')
+  }
+}
+
+export default { Products, Customers, Orders, Reservations, Users }


### PR DESCRIPTION
## Summary
- allow Resource.update to send configurable HTTP methods (default PATCH)
- ensure Products use PUT while Customers, Reservations, and Users send PATCH
- expose Users API resource

## Testing
- `npm test`
- `curl -s -w '\n' -X PATCH localhost:8000/customers/c1 -d '{"fullName":"Updated"}' -H 'Content-Type: application/json'`
- `curl -s -w '\n' -X PATCH localhost:8000/reservations/r1 -d '{"status":"CONFIRMED"}' -H 'Content-Type: application/json'`
- `curl -s -w '\n' -X PATCH localhost:8000/users/u1 -d '{"fullName":"User Updated"}' -H 'Content-Type: application/json'`


------
https://chatgpt.com/codex/tasks/task_e_68b857c7db64832ebfed261586f44f1e