### PR TITLE
Handle invalid JSON across controllers

### DIFF
--- a/backend/src/Controllers/CatalogController.php
+++ b/backend/src/Controllers/CatalogController.php
@@ -10,14 +10,19 @@ class CatalogController {
     return json($res,$q->fetchAll());
   }
   public function create($req,$res){
-    $d = (array) json_decode((string)$req->getBody(), true);
+    $d = json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d = (array) $d;
     $id = self::cuid('c');
     DB::pdo()->prepare("INSERT INTO catalog_item (id,name,code) VALUES (?,?,?)")
       ->execute([$id,$d['name'],$d['code']??null]);
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
-    $id=$args['id']; $d=(array) json_decode((string)$req->getBody(), true);
+    $id=$args['id'];
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $fields=[];$vals=[];
     foreach(['name','code'] as $f){ if(array_key_exists($f,$d)){ $fields[]="$f=?"; $vals[]=$d[$f]; } }
     if($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE catalog_item SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }

--- a/backend/src/Controllers/CustomersController.php
+++ b/backend/src/Controllers/CustomersController.php
@@ -30,7 +30,9 @@ class CustomersController {
     return json($res,$rows);
   }
   public function create($req,$res){
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $phones=$d['phones']??(isset($d['phone'])?[$d['phone']]:[]);
     $phones=array_values(array_filter($phones));
     if(!$phones){ return json($res,['error'=>'Phone required'],400); }
@@ -44,7 +46,9 @@ class CustomersController {
   }
   public function update($req,$res,$args){
     $id=$args['id'];
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $phones=$d['phones']??(isset($d['phone'])?[$d['phone']]:null);
     if($phones!==null){
       $phones=array_values(array_filter($phones));

--- a/backend/src/Controllers/LoyaltyController.php
+++ b/backend/src/Controllers/LoyaltyController.php
@@ -10,14 +10,19 @@ class LoyaltyController {
     return json($res,$q->fetchAll());
   }
   public function create($req,$res){
-    $d = (array) json_decode((string)$req->getBody(), true);
+    $d = json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d = (array)$d;
     $id = self::cuid('lp');
     DB::pdo()->prepare("INSERT INTO loyalty_program (id,name,discount) VALUES (?,?,?)")
       ->execute([$id,$d['name'],$d['discount']??null]);
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
-    $id=$args['id']; $d=(array) json_decode((string)$req->getBody(), true);
+    $id=$args['id'];
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $fields=[];$vals=[];
     foreach(['name','discount'] as $f){ if(array_key_exists($f,$d)){ $fields[]="$f=?"; $vals[]=$d[$f]; } }
     if ($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE loyalty_program SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }

--- a/backend/src/Controllers/OrdersController.php
+++ b/backend/src/Controllers/OrdersController.php
@@ -10,7 +10,9 @@ class OrdersController {
     return json($res,$st->fetchAll());
   }
   public function create($req,$res){
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $pdo=DB::pdo();
     $pdo->beginTransaction();
     try{

--- a/backend/src/Controllers/ProductsController.php
+++ b/backend/src/Controllers/ProductsController.php
@@ -13,7 +13,9 @@ class ProductsController {
     return json($res,$q->fetchAll());
   }
   public function create($req,$res){
-    $d = (array) json_decode((string)$req->getBody(), true);
+    $d = json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d = (array)$d;
     $id = self::cuid('p');
     DB::pdo()->prepare("INSERT INTO product (id,name,sku,type,unit,isWeightable,isActive,taxCode,groupId) VALUES (?,?,?,?,?,?,?,?,?)")
       ->execute([$id,$d['name'],$d['sku']??null,$d['type'],$d['unit'],(int)($d['isWeightable']??0),(int)($d['isActive']??1),$d['taxCode']??null,$d['groupId']??null]);
@@ -24,7 +26,10 @@ class ProductsController {
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
-    $id=$args['id']; $d=(array) json_decode((string)$req->getBody(), true);
+    $id=$args['id'];
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $fields=[];$vals=[];
     foreach(['name','sku','type','unit','isWeightable','isActive','taxCode','groupId'] as $f){ if(array_key_exists($f,$d)){ $fields[]="$f=?"; $vals[]=$d[$f]; } }
     if ($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE product SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }

--- a/backend/src/Controllers/ReservationsController.php
+++ b/backend/src/Controllers/ReservationsController.php
@@ -21,7 +21,9 @@ class ReservationsController {
     return json($res,$rows);
   }
   public function create($req,$res){
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $id='r_'.bin2hex(random_bytes(9));
     try{
       $start=Time::fromClient($d['startAt']);
@@ -38,7 +40,10 @@ class ReservationsController {
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
-    $id=$args['id']; $d=(array) json_decode((string)$req->getBody(), true);
+    $id=$args['id'];
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $fields=[];$vals=[];
     foreach(['status','startAt','endAt','prepayAmount','notes'] as $f){
       if(array_key_exists($f,$d)){

--- a/backend/src/Controllers/RolesController.php
+++ b/backend/src/Controllers/RolesController.php
@@ -10,14 +10,18 @@ class RolesController {
     return json($res,$st->fetchAll());
   }
   public function create($req,$res){
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $id='r_'.bin2hex(random_bytes(9));
     DB::pdo()->prepare("INSERT INTO roles (id,name) VALUES (?,?)")->execute([$id,$d['name']]);
     return json($res,['id'=>$id],201);
   }
   public function update($req,$res,$args){
     $id=$args['id'];
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     DB::pdo()->prepare("UPDATE roles SET name=? WHERE id=?")->execute([$d['name'],$id]);
     return json($res,['ok'=>true]);
   }

--- a/backend/src/Controllers/UsersController.php
+++ b/backend/src/Controllers/UsersController.php
@@ -12,7 +12,9 @@ class UsersController {
     return json($res,$rows);
   }
   public function create($req,$res){
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $id='u_'.bin2hex(random_bytes(9));
     DB::pdo()->prepare("INSERT INTO users (id,fullName,email) VALUES (?,?,?)")->execute([$id,$d['fullName'],$d['email']??null]);
     if(!empty($d['roles'])){
@@ -23,7 +25,9 @@ class UsersController {
   }
   public function update($req,$res,$args){
     $id=$args['id'];
-    $d=(array) json_decode((string)$req->getBody(), true);
+    $d=json_decode((string)$req->getBody(), true);
+    if(json_last_error()!==JSON_ERROR_NONE){ return json($res,['error'=>'Invalid JSON'],400); }
+    $d=(array)$d;
     $fields=[];$vals=[];
     foreach(['fullName','email'] as $f){ if(array_key_exists($f,$d)){ $fields[]="$f=?";$vals[]=$d[$f]; } }
     if($fields){ $vals[]=$id; DB::pdo()->prepare("UPDATE users SET ".implode(',',$fields)." WHERE id=?")->execute($vals); }

--- a/backend/tests/InvalidJsonTest.php
+++ b/backend/tests/InvalidJsonTest.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__.'/TestSupport.php';
+
+use App\Controllers\{
+    CatalogController,
+    CustomersController,
+    LoyaltyController,
+    OrdersController,
+    ProductsController,
+    ReservationsController,
+    RolesController,
+    UsersController
+};
+use App\DB;
+
+$controllers = [
+    new CatalogController(),
+    new CustomersController(),
+    new LoyaltyController(),
+    new OrdersController(),
+    new ProductsController(),
+    new ReservationsController(),
+    new RolesController(),
+    new UsersController(),
+];
+
+foreach ($controllers as $ctrl) {
+    DB::$pdo = new class {
+        public function prepare($sql){ return new class { public function execute($params){} }; }
+        public function query($sql){ return new class { public function fetchAll(){ return []; } }; }
+        public function beginTransaction() {}
+        public function commit() {}
+        public function rollBack() {}
+    };
+    $req = new class {
+        public function getBody(){ return '{'; }
+    };
+    $res = new \stdClass();
+    $out = $ctrl->create($req, $res);
+    assert($out->status === 400);
+    assert($out->body === ['error'=>'Invalid JSON']);
+}
+
+echo "Invalid JSON tests passed\n";


### PR DESCRIPTION
## Summary
- validate JSON payloads in all controllers and return 400 on malformed input
- add tests ensuring controllers respond with 400 for invalid JSON

## Testing
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/CustomersControllerTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/ReservationsControllerTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/InvalidJsonTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab9204e0832e8fa80f6736800447