### PR TITLE
Use backend API URL for login and document auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 ## Configuration
 
-Set the backend API base URL with the `NEXT_PUBLIC_API_URL` environment variable.
+Create a `.env.local` file and set the backend API base URL with the `NEXT_PUBLIC_API_URL` environment variable. This value is used by the login page to send requests to the backend.
 
 Example `.env.local`:
 
 ```
 NEXT_PUBLIC_API_URL=http://localhost:3000/backend
 ```
+
+### Authentication setup
+
+The frontend sends a `POST` request to `${NEXT_PUBLIC_API_URL}/login` and includes cookies via `credentials: 'include'`. Ensure the backend responds with JSON and sets an authentication cookie (for example, a session or JWT cookie). If the backend is hosted on a different domain, configure CORS to allow credentials.
 
 ## Development
 

--- a/main-dir/app/login/page.tsx
+++ b/main-dir/app/login/page.tsx
@@ -14,15 +14,21 @@ export default function LoginPage() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    const res = await fetch('/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    if (res.ok) {
-      router.push('/');
-    } else {
-      setError('Неверный логин или пароль');
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+        credentials: 'include'
+      });
+      const data = await res.json();
+      if (res.ok) {
+        router.push('/');
+      } else {
+        setError(data.message || 'Неверный логин или пароль');
+      }
+    } catch {
+      setError('Ошибка сети');
     }
   };
 


### PR DESCRIPTION
## Summary
- Fetch login from NEXT_PUBLIC_API_URL and include credentials
- Handle backend JSON responses and show server error messages
- Document `.env.local` and authentication setup in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b930bc0e8c832eaf8f96de531744fb