### PR TITLE
Validate token in middleware

### DIFF
--- a/main-dir/middleware.ts
+++ b/main-dir/middleware.ts
@@ -1,16 +1,28 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export function middleware(req: NextRequest) {
-  const token = req.cookies.get('token')?.value;
+export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  if (!token && pathname !== '/login' && !pathname.startsWith('/api')) {
-    return NextResponse.redirect(new URL('/login', req.url));
+  if (pathname.startsWith('/api')) {
+    return NextResponse.next();
   }
-  if (token && pathname === '/login') {
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/me`, {
+    headers: { cookie: req.headers.get('cookie') ?? '' },
+    credentials: 'include',
+  }).catch(() => null);
+
+  if (!res || !res.ok) {
+    const response = NextResponse.redirect(new URL('/login', req.url));
+    response.cookies.delete('token');
+    return response;
+  }
+
+  if (pathname === '/login') {
     return NextResponse.redirect(new URL('/', req.url));
   }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## Summary
- validate user token on each request by calling the /me API
- redirect to login and clear token when validation fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9372f7c3c832e8cc7a927b9190208