### PR TITLE
Handle camelCase customerId in reservation creation

### DIFF
--- a/backend/src/Controllers/ReservationsController.php
+++ b/backend/src/Controllers/ReservationsController.php
@@ -31,10 +31,10 @@ class ReservationsController {
     }catch(\Exception $e){
       return json($res,['error'=>'Invalid datetime'],400);
     }
-    if(empty($d['customer_id'])){
-      return json($res,['error'=>'customer_id required'],400);
+    $customerId = $d['customerId'] ?? $d['customer_id'] ?? null;
+    if (!$customerId) {
+      return json($res,['error'=>'customerId required'],400);
     }
-    $customerId=$d['customer_id'];
     DB::pdo()->prepare("INSERT INTO reservation (id,resourceId,customerId,status,startAt,endAt,prepayAmount,notes) VALUES (?,?,?,?,?,?,?,?)")
       ->execute([$id,$d['resourceId'],$customerId,$d['status']??'HELD',$start,$end,$d['prepayAmount']??null,$d['notes']??null]);
     return json($res,['id'=>$id],201);

--- a/backend/tests/ReservationsCreateTest.php
+++ b/backend/tests/ReservationsCreateTest.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__.'/TestSupport.php';
+
+use App\Controllers\ReservationsController;
+use App\DB;
+
+$body = json_encode([
+    'resourceId' => 'g1',
+    'customerId' => 'c1',
+    'startAt' => '2024-05-01T09:00:00Z',
+    'endAt'   => '2024-05-01T10:00:00Z'
+]);
+
+DB::$pdo = new class {
+    public $executed;
+    public function prepare($sql){
+        return new class($this) {
+            private $parent;
+            public function __construct($parent){ $this->parent = $parent; }
+            public function execute($params){ $this->parent->executed = $params; }
+        };
+    }
+};
+
+$req = new class($body) {
+    private $body;
+    public function __construct($body){ $this->body = $body; }
+    public function getBody(){ return $this->body; }
+};
+
+$res = new \stdClass();
+
+$controller = new ReservationsController();
+$out = $controller->create($req, $res);
+
+assert($out->status === 201);
+assert(isset($out->body['id']));
+assert(DB::$pdo->executed[2] === 'c1');
+
+echo "ReservationsController create test passed\n";


### PR DESCRIPTION
## Summary
- accept `customerId` when creating reservations
- add test verifying reservation creation with camelCase `customerId`

## Testing
- `npm test`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/CustomersControllerTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/InvalidJsonTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/ReservationsControllerTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/ReservationsCreateTest.php`
- `php -d auto_prepend_file=backend/vendor/autoload.php backend/tests/TimeTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9393edf5c832e8f9b223510e2ae13